### PR TITLE
Allow the selection of multiple flux networks, to speed up processing

### DIFF
--- a/R/ingest.R
+++ b/R/ingest.R
@@ -820,7 +820,7 @@ ingest <- function(
     bind_rows() %>%
     group_by(sitename) %>%
     nest() %>%
-    select(-contains("myvar"))
+    select(-"myvar")
 
   return(ddf)
 

--- a/R/ingest.R
+++ b/R/ingest.R
@@ -820,7 +820,7 @@ ingest <- function(
     bind_rows() %>%
     group_by(sitename) %>%
     nest() %>%
-    select(-"myvar")
+    select(-starts_with("myvar"))
 
   return(ddf)
 

--- a/R/ingest.R
+++ b/R/ingest.R
@@ -819,9 +819,8 @@ ingest <- function(
   ddf <- ddf %>%
     bind_rows() %>%
     group_by(sitename) %>%
-    nest() %>%
-    select(-starts_with("myvar"))
-
+    nest()
+  
   return(ddf)
 
 }

--- a/R/ingest_globalfields.R
+++ b/R/ingest_globalfields.R
@@ -113,6 +113,10 @@ ingest_globalfields <- function(
         dplyr::right_join(df_out, by = c("sitename", "date"))
     }
 
+    ## remove spurious myvar columns
+    df_out <- df_out %>%
+      select(-starts_with("myvar"))
+    
     if (timescale=="m"){
       rlang::abort("ingest_globalfields(): aggregating WATCH-WFDEI to monthly not implemented yet.")
     }

--- a/R/ingest_globalfields.R
+++ b/R/ingest_globalfields.R
@@ -26,7 +26,16 @@
 #'
 #' @examples \dontrun{inputdata <- ingest_bysite()}
 #'
-ingest_globalfields <- function( siteinfo, source, getvars, dir, timescale, standardise_units = TRUE, layer = NULL, verbose = FALSE ){
+ingest_globalfields <- function(
+  siteinfo,
+  source,
+  getvars,
+  dir,
+  timescale,
+  standardise_units = TRUE,
+  layer = NULL,
+  verbose = FALSE
+  ){
 
   if (!(source %in% c("etopo1", "wwf", "gsde", "worldclim"))){
     

--- a/R/ingest_modis_bysite.R
+++ b/R/ingest_modis_bysite.R
@@ -79,16 +79,29 @@ ingest_modis_bysite <- function( df_siteinfo, settings ){
                     )
             )
           )
+          
+          
         }
-        part_of_network <- df_siteinfo$sitename %in% sites_avl
+        
+        part_of_network <- df_siteinfo$sitename %in% sites_avl$network_siteid
       }
 
       if (part_of_network){
 
         try_mt_subset <- function(x, df_siteinfo, settings){
           
-          ## initial try
+          # grab required info
+          site <- sites_avl$network_siteid[
+            which(sites_avl$network_siteid %in% df_siteinfo$sitename)[1]
+            ]
+          network <- tolower(sites_avl$network[
+            which(sites_avl$network_siteid %in% df_siteinfo$sitename)[1]
+            ])
+          
+          # initial try
           rlang::inform(paste("Initial try for band", x))
+          rlang::inform(paste("of site", site))
+          rlang::inform(paste("and network", network))
           
           df <- try(
             MODISTools::mt_subset(
@@ -96,8 +109,8 @@ ingest_modis_bysite <- function( df_siteinfo, settings ){
               band      = x,
               start     = df_siteinfo$date_start,                 # start date: 1st Jan 2009
               end       = df_siteinfo$date_end,                   # end date: 19th Dec 2014
-              site_id   = df_siteinfo$sitename,                   # the site name we want to give the data
-              network   = settings$network,
+              site_id   = site,                   # the site name we want to give the data
+              network   = network,
               internal  = TRUE,
               progress  = TRUE
             )
@@ -113,8 +126,8 @@ ingest_modis_bysite <- function( df_siteinfo, settings ){
                 band      = x,
                 start     = df_siteinfo$date_start,                 # start date: 1st Jan 2009
                 end       = df_siteinfo$date_end,                   # end date: 19th Dec 2014
-                site_id   = df_siteinfo$sitename,                   # the site name we want to give the data
-                network   = settings$network,
+                site_id   = site,                   # the site name we want to give the data
+                network   = network,
                 internal  = TRUE,
                 progress  = TRUE
               )

--- a/R/ingest_modis_bysite.R
+++ b/R/ingest_modis_bysite.R
@@ -59,11 +59,26 @@ ingest_modis_bysite <- function( df_siteinfo, settings ){
         
       } else {
         ## check if site is available. see alse here: https://modis.ornl.gov/sites/
-        sites_avl <- MODISTools::mt_sites(network = settings$network) %>% as_tibble() %>% pull(network_siteid) %>% try()
+        sites_avl <- try(
+          do.call("rbind",
+                  lapply(settings_modis$network,
+                         function(network){MODISTools::mt_sites(network = network)
+                           }
+                         )
+                  )
+          )
+        
         while (class(sites_avl) == "try-error"){
           Sys.sleep(3)                                            # wait for three seconds
           rlang::warn("re-trying to get available sites...")
-          sites_avl <- MODISTools::mt_sites(network = settings$network) %>% as_tibble() %>% pull(network_siteid) %>% try()
+          sites_avl <- try(
+            do.call("rbind",
+                    lapply(settings_modis$network,
+                           function(network){MODISTools::mt_sites(network = network)
+                           }
+                    )
+            )
+          )
         }
         part_of_network <- df_siteinfo$sitename %in% sites_avl
       }


### PR DESCRIPTION
If listing multiple networks, will loop over list and combine the results.

This speeds up processing on heterogeneous sites lists which mix fluxnet and icos locations.